### PR TITLE
Fix the BTA logo not showing up on macOS

### DIFF
--- a/bta_src/BTADialog.xml
+++ b/bta_src/BTADialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <dialog title="Generate a Texture Atlas">
 	
-	<flash src="$CONFIGDIR\bta_src\BTAlogo.swf" width="610" height="72"></flash>
+	<flash src="$CONFIGDIR/bta_src/BTAlogo.swf" width="610" height="72"></flash>
 	
 	<hbox>
 		<label value=" " />


### PR DESCRIPTION
Replaces the backslashes with forward slashes
<img width="1440" height="850" alt="Screenshot 2026-02-24 at 10 26 08 PM" src="https://github.com/user-attachments/assets/70bcb695-2c2a-4a2f-b27d-f70db5476633" />

No idea if this works on Windows so please make sure to test this!